### PR TITLE
Removing deprecation warnings

### DIFF
--- a/simple_value_object/value_object.py
+++ b/simple_value_object/value_object.py
@@ -1,4 +1,4 @@
-from inspect import getfullargspec
+import sys
 import inspect
 
 from .exceptions import (
@@ -120,22 +120,27 @@ class ArgsSpec(object):
 
     def __init__(self, method):
         try:
-            self.fullargs = getfullargspec(method)
+            if sys.version_info.major == 2:
+                self.argspec = inspect.getargspec(method)
+                self.varkw = self.argspec.keywords
+            else:
+                self.argspec = inspect.getfullargspec(method)
+                self.varkw = self.argspec.varkw
         except TypeError:
             raise NotDeclaredArgsException()
 
     @property
     def args(self):
-        return self.fullargs.args
+        return self.argspec.args
 
     @property
     def varargs(self):
-        return self.fullargs.varargs
+        return self.argspec.varargs
 
     @property
     def keywords(self):
-        return self.fullargs.kwonlyargs
+        return self.varkw
 
     @property
     def defaults(self):
-        return self.fullargs.defaults
+        return self.argspec.defaults

--- a/simple_value_object/value_object.py
+++ b/simple_value_object/value_object.py
@@ -1,4 +1,4 @@
-from inspect import getargspec
+from inspect import getfullargspec
 import inspect
 
 from .exceptions import (
@@ -120,22 +120,22 @@ class ArgsSpec(object):
 
     def __init__(self, method):
         try:
-            self._args, self._varargs, self._keywords, self._defaults = getargspec(method)
+            self.fullargs = getfullargspec(method)
         except TypeError:
             raise NotDeclaredArgsException()
 
     @property
     def args(self):
-        return self._args
+        return self.fullargs.args
 
     @property
     def varargs(self):
-        return self._varargs
+        return self.fullargs.varargs
 
     @property
     def keywords(self):
-        return self._keywords
+        return self.fullargs.kwonlyargs
 
     @property
     def defaults(self):
-        return self._defaults
+        return self.fullargs.defaults


### PR DESCRIPTION
Change from inspect.getargspec() to inspect.getfullargspec() to remove deprecation warnings